### PR TITLE
Fix HEADERS_RECEIVED const typo

### DIFF
--- a/src/www/ios/xhr-polyfill.js
+++ b/src/www/ios/xhr-polyfill.js
@@ -1019,7 +1019,7 @@
 
 
   // define readonly const properties
-  ["UNSENT", "OPENED", "HEADERS_RECIEVED", "LOADING", "DONE"].forEach(function (propName, i)
+  ["UNSENT", "OPENED", "HEADERS_RECEIVED", "LOADING", "DONE"].forEach(function (propName, i)
   {
     Object.defineProperty(window.XMLHttpRequest.prototype, propName,
       {


### PR DESCRIPTION
AWS SDK fail due to HEADERS_RECEIVED cont typo in polyfill