### PR TITLE
allow xhr from the the application /Library path in addition to www d…

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This plugin makes it possible to reap the performance benefits of using the WKWebView in your Cordova app by resolving the following issues:
 
-* The default behavior of WKWebView is to raise a cross origin exception when loading files from the main bundle using the file protocol - "file://".  This plugin works around this shortcoming by loading files via native code if the web view's current location has "file" protocol and the target URL passed to the open method of the XMLHttpRequest is relative. As a security measure, the plugin verifies that the standardized path of the target URL is within the "www" folder of the application's main bundle.
+* The default behavior of WKWebView is to raise a cross origin exception when loading files from the main bundle using the file protocol - "file://".  This plugin works around this shortcoming by loading files via native code if the web view's current location has "file" protocol and the target URL passed to the open method of the XMLHttpRequest is relative. As a security measure, the plugin verifies that the standardized path of the target URL is within the "www" folder of the application's main bundle or in the /Library path of the application data directory.
 
 * Since the application's starting page is loaded from the device's file system, all XHR requests to remote endpoints are considered cross origin.  For such requests, WKWebView specifies "null" as the value of the Origin header, which will be rejected by endpoints that are configured to disallow requests from the null origin. This plugin works around that issue by handling all remote requests at the native layer where the origin header will be excluded.
 

--- a/src/ios/CDVWKWebViewFileXhr.m
+++ b/src/ios/CDVWKWebViewFileXhr.m
@@ -107,7 +107,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         NSURLSessionConfiguration *sessionConfiguration = [NSURLSessionConfiguration defaultSessionConfiguration];
         [sessionConfiguration setRequestCachePolicy:NSURLRequestReloadIgnoringCacheData];
-        self.urlSession = [NSURLSession sessionWithConfiguration:sessionConfiguration delegate:self delegateQueue:nil];
+        self.urlSession = [NSURLSession sessionWithConfiguration:sessionConfiguration delegate:self delegateQueue:nil]; // FortityFalsePositive
         [wkWebView.configuration.userContentController addScriptMessageHandler:self name:@"nativeXHR"];
 
     }

--- a/src/ios/CDVWKWebViewFileXhr.m
+++ b/src/ios/CDVWKWebViewFileXhr.m
@@ -268,7 +268,7 @@ NS_ASSUME_NONNULL_BEGIN
           CFDataRef exceptions = SecTrustCopyExceptions (serverTrust);
           SecTrustSetExceptions (serverTrust, exceptions);
           CFRelease (exceptions);
-          completionHandler (NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:serverTrust]);
+          completionHandler (NSURLSessionAuthChallengeUseCredential, [NSURLCredential credentialForTrust:serverTrust]); // FortityFalsePositive
          
           return;
         }
@@ -301,7 +301,8 @@ NS_ASSUME_NONNULL_BEGIN
     
     NSString *requestId = [body cdvwkStringForKey:@"id"];
     NSString *callbackFunction = [body cdvwkStringForKey:@"callback"];
-    NSString *urlString = [body cdvwkStringForKey:@"url"];
+    NSString *urlStringNotEncoded = [body cdvwkStringForKey:@"url"];
+    NSString *urlString = [urlStringNotEncoded stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.URLQueryAllowedCharacterSet];
     NSString *method = [body cdvwkStringForKey:@"method"];
     
     __weak WKWebView* weakWebView = webView;
@@ -313,7 +314,7 @@ NS_ASSUME_NONNULL_BEGIN
             NSData* json = [NSJSONSerialization dataWithJSONObject:result options:0 error:&jsonError];
             
             if (jsonError != nil) {
-                NSLog(@"NativeXHR: Failed to encode response to json: %@", jsonError.localizedDescription);
+                NSLog(@"NativeXHR: Failed to encode response to json: %@", jsonError.localizedDescription); // FortityFalsePositive
                 
                 NSString *script = [NSString stringWithFormat:@"try { %@('%@', {'error' : 'json serialization failed'}) } catch (e) { }", callbackFunction, requestId];
                 [weakWebView evaluateJavaScript:script completionHandler:nil];
@@ -339,7 +340,7 @@ NS_ASSUME_NONNULL_BEGIN
     NSURL *url = [NSURL URLWithString:urlString];
     
     if (![url.scheme.lowercaseString isEqualToString:@"http"] && ![url.scheme.lowercaseString isEqualToString:@"https"]) {
-        NSString *msg = [NSString stringWithFormat:@"NativeXHR: Invalid url scheme '%@';  only http and https are supported by NativeXHR", url.scheme];
+        NSString *msg = [NSString stringWithFormat:@"NativeXHR: Invalid url scheme '%@';  only http and https are supported by NativeXHR", urlString];
         return sendResult( @{ @"error" : msg});
     }
     
@@ -367,7 +368,7 @@ NS_ASSUME_NONNULL_BEGIN
         request.HTTPBody = [[NSData alloc] initWithBase64EncodedString:body64 options:0];
     }
     
-    NSURLSessionDataTask *task = [self.urlSession dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+    NSURLSessionDataTask *task = [self.urlSession dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) { // FortityFalsePositive
         
         NSMutableDictionary* result = [NSMutableDictionary dictionary];
         


### PR DESCRIPTION
A mobile application can download content to the application data directory and may want to serve content from this directory in addition to content from the application package. This needs xhr access to the device data directory (/Library) in addition to the application package (/www).

The purpose of the pull request is to add support for xhr content served from application data directory. 

We could potentially add a setting to the plugin to allow this new behavior. But I see no reason to add an additional config parameter.
