### PR TITLE
fix version number on plugin.xml so that it is consistent with packag…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cordova-plugin-wkwebview-file-xhr 2.1.3
+# cordova-plugin-wkwebview-file-xhr 2.1.4
 
 ## About the cordova-plugin-wkwebview-file-xhr
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-wkwebview-file-xhr",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "Cordova WKWebView File XHR Plugin",
   "cordova": {
     "id": "cordova-plugin-wkwebview-file-xhr",

--- a/plugin.xml
+++ b/plugin.xml
@@ -21,7 +21,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     id="cordova-plugin-wkwebview-file-xhr"
-    version="2.1.1">
+    version="2.1.4">
     <name>Cordova WKWebView File XHR Plugin</name>
     <description>This plugin includes the Apache Cordova WKWebView plugin and resolves XHR Cross-Origin Resource Sharing (CORS) constraints.</description>
     <license>UPL 1.0</license> 


### PR DESCRIPTION
 Found an issue with the latest version of cordova-plugin-wkwebview-file-xhr. The plugin.xml does not match the published version (or the version defined in package.json). This throws off Cordova framework when it is managing plugins.

Updated plugin.xml, package.json and Readme.md to 2.1.4. Once it is merge, I will do a new release and publish the changes to npm

