### PR TITLE
add space before the header value in getAllResponseHeaders

### DIFF
--- a/src/www/ios/xhr-polyfill.js
+++ b/src/www/ios/xhr-polyfill.js
@@ -1135,7 +1135,7 @@
     var names = Object.keys(responseHeaders);
     var list = [];
     for (var i = 0; i < names.length; i++)
-      list.push([names[i], responseHeaders[names[i]]].join(":"));
+      list.push([names[i], responseHeaders[names[i]]].join(": "));
 
     return list.join("\n");
   };


### PR DESCRIPTION
This pull request add a single space before header value (after colon).  then the polyfilled `getAllResponseHeaders()` will return the same format value with native

1. The origin http header
![image](https://user-images.githubusercontent.com/12423122/94771314-e772e380-03f1-11eb-9d8b-f4e7d10718a3.png)

2. Parsed response header
![image](https://user-images.githubusercontent.com/12423122/94771059-4edc6380-03f1-11eb-9757-8fbd55d625c1.png)

3. The return value of polyfilled getAllResponseHeaders()
**The space lost here**
![image](https://user-images.githubusercontent.com/12423122/94771141-7fbc9880-03f1-11eb-8764-90db23e09023.png)

4. **The FIRST CHAR LOST**.
Some 3rd libraries like  [azure-sdk-for-js](https://github.com/Azure/azure-sdk-for-js) makes http request by using `XMLHttpRequest` and parses header by itself just like following code
https://github.com/Azure/azure-sdk-for-js/blob/744e51acb755db2c565c71a8856d8d13e6ec345b/sdk/core/core-https/src/xhrHttpsClient.ts#L129
If the return value from the polyfilled function [XMLHttpRequest.getAllResponseHeaders()](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/getAllResponseHeaders) is not keeps the exact same format (`Date: Thu, 01 Oct 2020 05:18:27 GMT\r\n`) as the original value, some thing will broken.
![image](https://user-images.githubusercontent.com/12423122/94771502-54867900-03f2-11eb-84ba-d0af44fd1f18.png)

![image](https://user-images.githubusercontent.com/12423122/94772954-c44a3300-03f5-11eb-8a2c-9138ce1b63d8.png)
